### PR TITLE
Fix TypeError by ensuring countries is an array

### DIFF
--- a/scripts/dom/file-info-find-on.js
+++ b/scripts/dom/file-info-find-on.js
@@ -190,6 +190,10 @@ function get(name)
 
 	let globalList = structuredClone(findOn.global);
 	let countries = dom.fileInfo.country.get();
+	// If countries isn't set as an array, it returns null and causes an uncaught TypeError.
+	if (!Array.isArray(countries)) {
+        countries = [];
+    }
 
 	let list = {
 		store: {


### PR DESCRIPTION
Handle case where countries is not an array to prevent TypeError.

can edit rest of the stuff if you like, i do feel like the country specific is important, but when it returns null, it causes this:

```
[Window Title]
Linenumber 241:33

[Main Instruction]
Error: Uncaught TypeError: Cannot read properties of null (reading 'length') at linenumber 241:33 of file C:\Users\x\AppData\Local\Programs\opencomic\resources\app.asar\scripts\dom\file-info-find-on.js

[Content]
TypeError: Cannot read properties of null (reading 'length')
    at Object.get (C:\Users\x\AppData\Local\Programs\opencomic\resources\app.asar\scripts\dom\file-info-find-on.js:241:33)
    at HTMLDivElement.onclick (file:///C:/Users/x/AppData/Local/Programs/opencomic/resources/app.asar/templates/index.html:1:21)

[OK]
```