### PR TITLE
Fix failed to connect to Wayland display

### DIFF
--- a/build/flathub/app.opencomic.OpenComic.yml
+++ b/build/flathub/app.opencomic.OpenComic.yml
@@ -7,7 +7,8 @@ base-version: '24.08'
 command: run.sh
 separate-locales: false
 finish-args:
-  - --socket=x11
+  - --socket=wayland
+  - --socket=fallback-x11
   - --socket=pulseaudio
   - --device=dri
   - --share=network


### PR DESCRIPTION
This change enables the Wayland socket in the Flatpak manifest, fixing
startup failures on Wayland sessions (#472 ) with recent Electron versions.

By allowing native Wayland usage instead of the X11 → XWayland → Wayland
bridge, this should also reduce the likelihood of rendering and input
issues on Wayland-based desktops.